### PR TITLE
Code refactor and added Monolith POL and average POL

### DIFF
--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -89,8 +89,6 @@ export class Ohmie extends Entity {
   constructor(id: string) {
     super();
     this.set("id", Value.fromString(id));
-
-    this.set("active", Value.fromBoolean(false));
   }
 
   save(): void {
@@ -1657,6 +1655,40 @@ export class ProtocolMetric extends Entity {
 
   set treasuryOhmDaiPOL(value: BigDecimal) {
     this.set("treasuryOhmDaiPOL", Value.fromBigDecimal(value));
+  }
+
+  get treasuryMonolithPOL(): BigDecimal | null {
+    let value = this.get("treasuryMonolithPOL");
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigDecimal();
+    }
+  }
+
+  set treasuryMonolithPOL(value: BigDecimal | null) {
+    if (!value) {
+      this.unset("treasuryMonolithPOL");
+    } else {
+      this.set("treasuryMonolithPOL", Value.fromBigDecimal(<BigDecimal>value));
+    }
+  }
+
+  get treasuryAveragePOL(): BigDecimal | null {
+    let value = this.get("treasuryAveragePOL");
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigDecimal();
+    }
+  }
+
+  set treasuryAveragePOL(value: BigDecimal | null) {
+    if (!value) {
+      this.unset("treasuryAveragePOL");
+    } else {
+      this.set("treasuryAveragePOL", Value.fromBigDecimal(<BigDecimal>value));
+    }
   }
 
   get holders(): BigInt {

--- a/schema.graphql
+++ b/schema.graphql
@@ -141,6 +141,8 @@ type ProtocolMetric @entity {
   runway100k: BigDecimal
   runwayCurrent: BigDecimal
   treasuryOhmDaiPOL: BigDecimal!
+  treasuryMonolithPOL: BigDecimal
+  treasuryAveragePOL: BigDecimal
   holders: BigInt!
   index: BigDecimal!
   ohmMinted: BigDecimal!

--- a/src/utils/ProtocolMetrics.ts
+++ b/src/utils/ProtocolMetrics.ts
@@ -142,12 +142,13 @@ function getMonolithInfo(tokenAddresses: Address[], tokenBalances: BigInt[], tre
 }
 
 function getAveragePol(slpBalance: BigDecimal, slpTotalSupply: BigDecimal, monolithBalance: BigDecimal, monolithTotalSupply: BigDecimal):BigDecimal {
-    return
+    return ( 
         slpBalance.plus(monolithBalance)
         .div(
             slpTotalSupply.plus(monolithTotalSupply)
         )
         .times(BigDecimal.fromString("100"))
+    )
 }
 
 class ITreasury {
@@ -217,18 +218,17 @@ function getMV_RFV(transaction: Transaction): ITreasury{
     const monolithAddresses = monolithPoolTokens.value0
     const monolithBalances = monolithPoolTokens.value1
 
-    const {
-        monolithMaiValue,
-        monolithMaiBalance,
-        monolithExodValue,
-        monolithExodBalance,
-        monolithWsExodValue,
-        monolithWsExodBalance,
-        monolithGOhmValue,
-        monolithGOhmBalance,
-        monolithWFtmValue,
-        monolithWFtmBalance
-    } = getMonolithInfo(monolithAddresses, monolithBalances, treasuryOwnedMonolithRatio, index)
+    const monolithInfo = getMonolithInfo(monolithAddresses, monolithBalances, treasuryOwnedMonolithRatio, index)
+    const monolithMaiValue = monolithInfo.monolithMaiValue
+    const monolithMaiBalance = monolithInfo.monolithMaiBalance
+    const monolithExodValue = monolithInfo.monolithExodValue
+    const monolithExodBalance = monolithInfo.monolithExodBalance
+    const monolithWsExodValue = monolithInfo.monolithWsExodValue
+    const monolithWsExodBalance = monolithInfo.monolithWsExodBalance
+    const monolithGOhmValue = monolithInfo.monolithGOhmValue
+    const monolithGOhmBalance = monolithInfo.monolithGOhmBalance
+    const monolithWFtmValue = monolithInfo.monolithWFtmValue
+    const monolithWFtmBalance = monolithInfo.monolithWFtmBalance
 
     const gohmPrice = monolithGOhmValue.div(monolithGOhmBalance);
     const totalGOhmBalance = gOhmBalance.plus(monolithGOhmBalance);

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -1,7 +1,7 @@
 specVersion: 0.0.2
 description: Exodia DAO Subgraph
 graft:
-  base: QmQe4pwHd6eEAXwTV3Gs1KVzbRwkjqHbxveFb1dktBi7Uq
+  base: QmVB75bWzWuGveBUpFc9aQTYhfWQwYz4xdQUZ6HcYtccx4
   block: 27463550
 repository: https://github.com/ExodiaFinance/exodia-subgraph
 schema:


### PR DESCRIPTION
## Changes
- Refactored the monolith balances and values assignment part into a single function that returns a single object with all the token balances and values
- Added two new fields to protocolMetric:
  1. treasuryMonolithPOL: percentage of treasury owned monolith BPT
  2. treasuryAveragePOL: average percentage of treasury owned exoddai LP and monolith BPT
- Refactored some code for more consistency
- Updated graft base hash